### PR TITLE
CI: add GitHub Actions (lint, unit+coverage, e2e; publish Allure) + PR/Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: 🐞 Bug report
+about: Report a bug in tests or framework
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+## 🐛 Bug description
+<!-- Briefly describe the problem -->
+
+## 🔄 Steps to reproduce
+1.
+2.
+3.
+
+## ✅ Expected behavior
+<!-- What was expected -->
+
+## 🚫 Actual behavior
+<!-- What really happened -->
+
+## 📷 Screenshots / Logs
+<!-- If there is, please attach it. -->
+
+## 🖥 Environment
+- OS: [e.g. Ubuntu 22.04]
+- Python: [e.g. 3.13]
+- Browser: [e.g. Chrome 140 headless]
+- pytest version:
+- selenium version:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Documentation
+    url: https://github.com/SharaiR/pytest_and_selenium#readme
+    about: Please check the README before creating an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: ✨ Feature request
+about: Suggest a new feature or improvement
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+## 🚀 Feature description
+<!-- What to add/change -->
+
+## 📝 Example use case
+<!-- How to use -->
+
+## 🔗 Related
+<!-- Links to discussions/PR/issues -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## 📌 Summary
+<!-- Briefly: What has changed in this PR? -->
+
+## 🔍 Details
+- [ ] Added new tests
+- [ ] Updated documentation (README, env.example)
+- [ ] Changes to Page Object / fixtures
+- [ ] Configured CI/CD (GitHub Actions, reports)
+
+## ✅ Checks before review
+- [ ] Passes `pytest tests/unit` locally
+- [ ] Passes `pytest -m "smoke" --headless` locally
+- [ ] Passes `flake8` and `black --check`
+- [ ] Updated `.env.example` on environment changes
+
+## 🔗 Related
+<!-- Links to commits, issues, or previous PRs -->

--- a/.github/workflow/ci.yml
+++ b/.github/workflow/ci.yml
@@ -1,0 +1,188 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master, feature/** ]
+  pull_request:
+    branches: [ main, master ]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint (black & flake8)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: black --check
+        run: black --check .
+
+      - name: flake8
+        run: flake8 src tests
+
+  unit:
+    name: Unit tests + coverage
+    runs-on: ubuntu-latest
+    needs: lint
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Use .env.example
+        run: cp .env.example .env
+
+      - name: Run unit tests with coverage
+        run: |
+          pytest tests/unit --cov=src --cov-report=term-missing \
+            --cov-report=xml:reports/coverage/coverage.xml
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: reports/coverage/coverage.xml
+          if-no-files-found: error
+          retention-days: 7
+
+  e2e:
+    name: E2E (headless Chrome, xdist)
+    runs-on: ubuntu-latest
+    needs: unit
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: ${{ runner.os }}-pip-
+
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      # Install Google Chrome (Selenium Manager will automatically select the Chromedriver)
+      - name: Install Google Chrome
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget gnupg
+          wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo gpg --dearmor -o /usr/share/keyrings/google-linux.gpg
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-linux.gpg] http://dl.google.com/linux/chrome/deb/ stable main" | \
+            sudo tee /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y google-chrome-stable
+          google-chrome --version
+
+      - name: Use .env.example
+        run: cp .env.example .env
+
+      - name: Run smoke (HTML report)
+        run: |
+          pytest -m "smoke" --browser=chrome --headless \
+            --html=reports/report.html --self-contained-html -n auto
+
+      - name: Run e2e/regression (Allure)
+        run: |
+          pytest -m "e2e or regression" --browser=chrome --headless \
+            --alluredir=reports/allure-results -n auto
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: html-report
+          path: reports/report.html
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload Allure results
+        uses: actions/upload-artifact@v4
+        with:
+          name: allure-results
+          path: reports/allure-results/
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload screenshots (on failures)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots
+          path: artifacts/screenshots/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # Generating and publishing an Allure report on GitHub Pages
+  allure_pages:
+    name: Publish Allure to GitHub Pages
+    runs-on: ubuntu-latest
+    needs: e2e
+
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Allure results
+        uses: actions/download-artifact@v4
+        with:
+          name: allure-results
+          path: allure-results
+
+      # Generate an Allure report using a ready-made action (there's already a CLI inside)
+      - name: Generate Allure report
+        uses: simple-elf/allure-report-action@v1.7
+        with:
+          allure_results: allure-results
+          allure_report: allure-report
+          keep_reports: 5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: allure-report
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@
 ![coverage](https://img.shields.io/badge/coverage-100%25-brightgreen)
 [![flake8](https://img.shields.io/badge/lint-flake8-lightgrey.svg)]()
 ![Black](https://img.shields.io/badge/code%20style-black-000000.svg)
-![Allure](https://img.shields.io/badge/report-Allure-ff69b4)
+<!-- ![Allure](https://img.shields.io/badge/report-Allure-ff69b4) -->
+[![CI](https://github.com/SharaiR/pytest_and_selenium/actions/workflows/ci.yml/badge.svg)](https://github.com/SharaiR/pytest_and_selenium/actions)
+[Allure Report (latest)](https://sharair.github.io/pytest_and_selenium/)
 
 A modern **Pytest + Selenium** template project with Page Object Model (POM), fixtures, screenshots on failures and ready-to-use reporting (HTML & Allure).
 
@@ -136,6 +138,11 @@ python3 -m coverage html -d reports/coverage
 ```bash
 .
 ├── .github/
+│   ├── PULL_REQUEST_TEMPLATE.md
+│   ├── ISSUE_TEMPLATE/
+│       ├── bug_report.md
+│       ├── feature_request.md
+│       └── config.yml
 │   └── workflows/
 │       └── ci.yml
 ├── artifacts/                      # Screenshots on failure


### PR DESCRIPTION
### Summary
Add a complete CI pipeline and repository templates:
- GitHub Actions workflow (`lint` → `unit` → `e2e` → `allure_pages`)
- PR/Issue templates for consistent contribution flow

### Details
- Lint: `black --check`, `flake8 src tests`
- Unit: `pytest tests/unit --cov=src`, upload `coverage.xml`
- E2E: Chrome headless, pytest-xdist (`-n auto`), HTML & Allure outputs
- Allure: publish to GitHub Pages via `allure_pages` job
- `.env.example` includes `BASE_URL`, `E2E_DEFAULT_USER`, `E2E_USERS_JSON`, `SKIP_PRERUN_CHECK`
- Added repository templates:
  - `.github/PULL_REQUEST_TEMPLATE.md`
  - `.github/ISSUE_TEMPLATE/bug_report.md`
  - `.github/ISSUE_TEMPLATE/feature_request.md`
  - `.github/ISSUE_TEMPLATE/config.yml`

### How to enable
- Settings → Actions → Allow all actions
- Settings → Pages → Source: GitHub Actions

### Artifacts
- Coverage XML: `reports/coverage/coverage.xml`
- HTML report: `reports/report.html`
- Allure results: `reports/allure-results/`
- Screenshots on failures: `artifacts/screenshots/`
